### PR TITLE
feat: categories for cloudwatch log entries

### DIFF
--- a/cloudwatch-firehose-es/src/run.py
+++ b/cloudwatch-firehose-es/src/run.py
@@ -51,6 +51,7 @@ import json
 import gzip
 import boto3
 import datetime
+import os
 
 
 def transformLogEvent(log_event, cloudwatch_info):
@@ -111,45 +112,56 @@ def processRecords(records):
                 if i == 0:
                     cw_log_data = transformLogEvent(event, cloudwatch_info)
 
-                    # Determine if extra ways to categorize the event were provided
-                    categories = getattr(cw_log_data, 'categories', [] )
-                    if not isinstance(categories, list):
-                        categories = [categories]
+                    # Check if we want to categorize on the basis of an attribute
+                    categorization_attribute = os.environ.get("CATEGORIZATION_ATTRIBUTE", None)
 
-                    # Get unique categories - ensure Logs is always in the list at a minimum
-                    categories = list(set(categories.append('Logs')))
+                    if categorization_attribute is not None:
 
-                    for j,category in enumerate(categories):
-                        if j == 0:
-                            cw_log_data['categories'] = category
+                        # Determine if extra ways to categorize the event were provided
+                        categories = getattr(cw_log_data, categorization_attribute, [] )
+                        if not isinstance(categories, list):
+                            categories = [categories]
 
-                            yield {
-                                'data' : str(base64.b64encode(cw_log_data.encode()), 'utf-8'),
-                                'result' : 'Ok',
-                                'recordId' : recId,
-                                'metadata' : {
-                                    'partitionKeys': {
-                                        'category' : category
+                        # Get unique categories - ensure "Logs" is always in the list at a minimum
+                        categories = list(set(categories.append('Logs')))
+
+                        for j,category in enumerate(categories):
+                            if j == 0:
+                                cw_log_data['categories'] = category
+
+                                yield {
+                                    'data' : str(base64.b64encode(cw_log_data.encode()), 'utf-8'),
+                                    'result' : 'Ok',
+                                    'recordId' : recId,
+                                    'metadata' : {
+                                        'partitionKeys': {
+                                            'category' : category
+                                        }
                                     }
                                 }
-                            }
 
-                        else:
-                            category_event = event
-                            category_event['categories'] = [category]
+                            else:
+                                category_event = event
+                                category_event['categories'] = [category]
 
-                            reingest_event = data
-                            reingest_event['logEvents'] = [ category_event ]
+                                reingest_event = data
+                                reingest_event['logEvents'] = [ category_event ]
 
-                            reingest_json = json.dumps(reingest_event)
-                            reingest_bytes = reingest_json.encode('utf-8')
-                            reignest_compress = gzip.compress(reingest_bytes)
+                                reingest_json = json.dumps(reingest_event)
+                                reingest_bytes = reingest_json.encode('utf-8')
+                                reignest_compress = gzip.compress(reingest_bytes)
 
-                            yield {
-                                'data' : str( base64.b64encode( reignest_compress ), 'utf-8'),
-                                'result' : 'Reingest',
-                                'recordId' : recId
-                            }
+                                yield {
+                                    'data' : str( base64.b64encode( reignest_compress ), 'utf-8'),
+                                    'result' : 'Reingest',
+                                    'recordId' : recId
+                                }
+                    else:
+                        yield {
+                            'data' : str(base64.b64encode(cw_log_data.encode()), 'utf-8'),
+                            'result' : 'Ok',
+                            'recordId' : recId
+                        }
 
                 else:
 


### PR DESCRIPTION

## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Support the ability for a cloud watch log event to explicitly include a unique list of categories that it should be saved under.

If no explicit categories are provided, the event is always considered to carry the "Logs" category.

If multiple categories, return a record per category.

Provide the category as a partition value.

## Motivation and Context
Support separation of logs into categories to reduce the volume of records to be processed by specific consumers such as the SIEM.

## How Has This Been Tested?
Customer deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

