### PR TITLE
refactor: timezone in timestamp

### DIFF
--- a/cloudwatch-firehose-es/src/run.py
+++ b/cloudwatch-firehose-es/src/run.py
@@ -69,7 +69,7 @@ def transformLogEvent(log_event, cloudwatch_info):
 
     json_event = {}
 
-    isotime = datetime.datetime.utcfromtimestamp( log_event['timestamp'] / 1000 ).isoformat()
+    isotime = datetime.datetime.fromtimestamp( log_event['timestamp'] / 1000, tz=datetime.timezone.utc ).isoformat()
 
     try:
         json_event = json.loads(log_event['message'])
@@ -216,6 +216,7 @@ def putRecordsToFirehoseStream(streamName, records, client, attemptsMade, maxAtt
             for record in records:
                 with gzip.open(BytesIO(record['Data']), 'rb') as f:
                     print(json.loads(f.read()))
+        # Comment out the following line if testing locally
         response = client.put_record_batch(DeliveryStreamName=streamName, Records=records)
     except Exception as e:
         failedRecords = records


### PR DESCRIPTION

## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Ensure a timezone is always included in timestamps when converting the cloudwatch timestamp into an ISO 8601 string.

## Motivation and Context
Previously no timezone was included in the timestamp meaning there was ambiguity in the records produced. Cloudwatch uses UTC so ensure this is reflected in the timestamps.

## How Has This Been Tested?
Locally tested

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

